### PR TITLE
Explicitly pass `cwd` to the sass resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.2.13 (unreleased)
+======
+
+*   (improvement) Explicitly pass `cwd` to the sass resolver, so that it works even if Firefly is installed via symlink.
+
+
 1.2.12
 ======
 

--- a/src/builder/scss/ScssCompiler.ts
+++ b/src/builder/scss/ScssCompiler.ts
@@ -114,7 +114,7 @@ export class ScssCompiler
 				outputStyle: 'expanded',
 				sourceMap: true,
 				includePaths: [this.base],
-				importer: resolveScssImport,
+				importer: (url: string, prev: string) => resolveScssImport(this.base, url, prev),
 			});
 		}
 		catch (e)

--- a/src/builder/scss/resolver.ts
+++ b/src/builder/scss/resolver.ts
@@ -2,7 +2,7 @@ import {ImporterReturnType} from 'sass';
 import * as path from 'path';
 import {readFileSync} from 'fs-extra';
 
-export function resolveScssImport (url: string, prev: string): ImporterReturnType
+export function resolveScssImport (cwd: string, url: string, prev: string): ImporterReturnType
 {
 	if ("~" === url[0])
 	{
@@ -15,7 +15,9 @@ export function resolveScssImport (url: string, prev: string): ImporterReturnTyp
 
 			try
 			{
-				const resolvedPath = require.resolve(fullImportPath);
+				const resolvedPath = require.resolve(fullImportPath, {
+					paths: [cwd],
+				});
 
 				if (".scss" !== path.extname(resolvedPath))
 				{


### PR DESCRIPTION
Explicitly pass `cwd` to the sass resolver, so that it works even if Firefly is installed via symlink.